### PR TITLE
Added RM Functionality to FAMFS

### DIFF
--- a/src/famfs_cli.c
+++ b/src/famfs_cli.c
@@ -1583,6 +1583,30 @@ do_famfs_cli_chkread(int argc, char *argv[])
 /********************************************************************/
 
 
+
+
+/**************AJINKYA CHANGE***********************/
+
+int do_famfs_cli_rm(int argc, char *argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <file_path>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+	int error;
+	for (int i = 2; i < argc; i++) {
+		error = famfs_rm(argv[i]);
+		if (error == -1){
+			fprintf(stderr, "Error in removal of %s\n", argv[i]);
+			return EXIT_FAILURE;
+		}
+	}
+    return 0;
+}
+/******************************************************************/
+
+
+
+
 struct famfs_cli_cmd {
 	char *cmd;
 	int (*run)(int argc, char **argv);
@@ -1607,7 +1631,7 @@ famfs_cli_cmd famfs_cli_cmds[] = {
 	{"getmap",  do_famfs_cli_getmap,  famfs_getmap_usage},
 	{"clone",   do_famfs_cli_clone,   famfs_clone_usage},
 	{"chkread", do_famfs_cli_chkread, famfs_chkread_usage},
-
+	{"rm", do_famfs_cli_rm, NULL},  //Ajinkya Change
 	{NULL, NULL, NULL}
 };
 
@@ -1677,4 +1701,3 @@ main(int argc, char **argv)
 
 	return -1;
 }
-

--- a/src/famfs_lib.h
+++ b/src/famfs_lib.h
@@ -57,4 +57,10 @@ int famfs_flush_file(const char *filename, int verbose);
 int file_not_famfs(const char *fname);
 s64 get_multiplier(const char *endptr);
 
+
+/**************AJINKYA CHANGE***********************/
+int famfs_rm(const char *filepath);
+int famfs_free_file_memory(const char *filepath);
+/**************************************************/
+
 #endif /* _H_FAMFS_LIB */


### PR DESCRIPTION
In this commit, we implement a new `rm` functionality to the list of cli functions supported by famfs. Our implementation involves modifying two existing internal famfs functions: `famfs_build_bitmap()` and `__famfs_logplay()`. We modify these functions to be able to skip log entries of files that have been deleted, thus marking the data blocks used by the file as available for allocation on new file creation. We also implement two new functions: `famfs_free_file_memory()` and `famfs_rm()`. These functions are responsible for checking the inputs to `rm`, overwriting the old log entry with a log entry that reflects the deletion of the file, and unlinking the file.